### PR TITLE
Ticket creation handler

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+src/node_modules
+src/npm-debug.log
+src/persistedGlobalState.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM node:18
+
+WORKDIR /usr/src/app
+
+COPY src/package*.json ./
+
+RUN npm install
+
+COPY src .
+
+EXPOSE 8999
+
+CMD [ "node", "app.js" ]
+

--- a/src/api/apiroutes.js
+++ b/src/api/apiroutes.js
@@ -3,7 +3,7 @@ import { apiGetTicketComments } from "./comments.js"
 import { normalizeId, errNotImplemented } from "./helpers.js"
 import { apiGetJobById } from "./jobresults.js"
 import { apiSearch } from "./search.js"
-import { apiTicketsImportCreateMany, apiTicketsShowMany, apiTicketUpdateMany } from "./tickets.js"
+import { apiTicketsImportCreateMany, apiTicketsShowMany, apiTicketCreate, apiTicketUpdateMany } from "./tickets.js"
 import { apiUsersSearchByEmail, apiUsersCreateMany, apiUsersShowMany } from "./users.js"
 
 /**
@@ -69,6 +69,13 @@ export function apiRoutes(app) {
         wrapHandler(() => {
             const result = apiTicketUpdateMany(req.body)
             res.send(result)
+        }, req, res)
+    })
+
+    register('post', '/api/v2/tickets', (req, res) => {
+        wrapHandler(() => {
+            const result = apiTicketCreate(req.body)
+            res.set('Location', result.url).status(201).send(result)
         }, req, res)
     })
 

--- a/src/api/helpers.js
+++ b/src/api/helpers.js
@@ -42,19 +42,16 @@ export function generateCommentId(persistedState) {
 }
 
 /**
- * Generate a ticket id, randomly chosen integer
- * In actual zendesk these are always increasing
+ * Generate a ticket id, increasing and updating the last generated value persisted in the state
  */
 export function generateTicketId(persistedState) {
-    assert(persistedState['tickets'])
-    for (let i = 0; i < 5; i++) {
-        let candidate = genCandidate()
-        if (!persistedState['tickets'][candidate]) {
-            return candidate
-        }
+    let ticket_id = persistedState['last_ticket_id'] ? persistedState['last_ticket_id'] + 1 : 1
+    // If for any reason a ticket with the new id existed, keep increasing the value
+    while (persistedState.tickets && persistedState.tickets[ticket_id]) {
+        ticket_id++
     }
-
-    assert(false, 'could not generate ticket id')
+    persistedState['last_ticket_id'] = ticket_id
+    return ticket_id
 }
 
 /**

--- a/src/api/schema.js
+++ b/src/api/schema.js
@@ -67,7 +67,8 @@ export function validateInternalTicket(obj) {
         // via: not yet implemented
         custom_fields: yup.array().of(yup.object({
             id: yup.number().required().positive().integer(),
-            value: yup.mixed().required()
+            // NOTE: value may be null
+            value: yup.mixed()
         })).required(),
         fields: yup.array().of(yup.object({
             id: yup.number().required().positive().integer(),


### PR DESCRIPTION
Added handler for `/api/v2/tickets` endpoint for creating tickets. 
Current implementation is based on the import endpoint, and uses methods like transformIncomingTicketImportIntoInternal that may be specific for the import scenario. There is code duplication that can be refactored.
The endpoint returns a Location header with the ticket id, since this is what Zendesk do and Python's zdesk client expect.

Added `Dockerfile` and `.dockerignore` files to allow docker image creation